### PR TITLE
Use kernel-side pyflyby to insert and refomat imports.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["jupyter_packaging~=0.4.0", "jupyterlab~=2.0", "setuptools>=40.8.0", "wheel"]
+requires = ["jupyter_packaging~=0.4.0", "jupyterlab~=2.0", "setuptools>=40.8.0", "wheel", "jupyter_server<0.1.1", "pyzmq"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This fixes issues where import could be added in the middle of multiline
imports. I am not too sure if this will be have correctly in all the
case, in particular if there is multiple imports at once, but that might
need to be fixed in pyflyby itself to send a single mesage in the comms
with the list of imports to add.