### PR TITLE
Fix imports from long running cells not added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [4.2.0](https://github.com/deshaw/jupyterlab-pyflyby/compare/v4.1.1...v4.2.0) (UNRELEASED)
+
+### Fixed
+
+- Fix imports from long running cells not showing up.
+
 ## [4.1.1](https://github.com/deshaw/jupyterlab-pyflyby/compare/v4.1.0...v4.1.1) (2022-01-25)
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deshaw/jupyterlab-pyflyby",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "A labextension to integrate pyflyby with notebooks",
   "keywords": [
     "jupyter",

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -15,7 +15,7 @@
       "description": "Inform when pyflyby starts to add imports for the first time. Since this adds imports to the top cell, it may not be obvious to user",
       "default": false
     },
-    "experimentalLockTimeout": {
+    "lockTimeout": {
       "type": "number",
       "title": "The timeout (in sec) for when the import locks should expire. If a lock expires then the import will be skipped being added.",
       "default": 10

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -14,6 +14,11 @@
       "title": "Show notification when PYFLYBY starts adding imports to notebook",
       "description": "Inform when pyflyby starts to add imports for the first time. Since this adds imports to the top cell, it may not be obvious to user",
       "default": false
+    },
+    "lockTimeout": {
+      "type": "number",
+      "title": "The timeout (in sec) for when the import locks should expire. If a lock expires then the import will be skipped being added.",
+      "default": 999999
     }
   }
 }

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -15,10 +15,10 @@
       "description": "Inform when pyflyby starts to add imports for the first time. Since this adds imports to the top cell, it may not be obvious to user",
       "default": false
     },
-    "lockTimeout": {
+    "experimentalLockTimeout": {
       "type": "number",
       "title": "The timeout (in sec) for when the import locks should expire. If a lock expires then the import will be skipped being added.",
-      "default": 999999
+      "default": 10
     }
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -95,12 +95,14 @@ class CommLock {
   }
 
   async acquire(): Promise<number> {
-    const lockId = this.requestedLockCount++;
-    this.promise[this.requestedLockCount] = new Promise(resolve => {
-      this._releaseLock[this.requestedLockCount] = resolve;
+    const lastLockPromise = this.promise[this.requestedLockCount];
+    this.requestedLockCount++;
+    const lockId = this.requestedLockCount;
+    this.promise[lockId] = new Promise(resolve => {
+      this._releaseLock[lockId] = resolve;
     });
-    await this.promise[lockId];
-    return new Promise((res, rej) => res(lockId + 1));
+    await lastLockPromise;
+    return new Promise((res, rej) => res(lockId));
   }
 
   release(lockId: number): void {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -153,8 +153,8 @@ class PyflyByWidget extends Widget {
 
         const _lockTimeout =
           1000 *
-          ((settings.get('experimentalLockTimeout').user ||
-            settings.get('experimentalLockTimeout').composite) as number);
+          ((settings.get('lockTimeout').user ||
+            settings.get('lockTimeout').composite) as number);
         this._lock = new CommLock(_lockTimeout, this._sessionContext);
       },
       (err: any) => {


### PR DESCRIPTION
This PR improves the lock mechanism implemented in #7.

Instead of starting timeouts immediately as the lock is acquired, we wait
till the previous lock expires to start the timeout for the next.

Also, if the current timeout expires when the kernel is busy, we restart
it because the kernel is most likely executing code and we cannot
process the message at that point.

Finally, the timeout of the locks is set to 999999 secs by default which
essentially disables the locks by default and most users shouldn't need
to change this setting. This is required to be lowered only when in a
lossy/slow network. When a lock expires, the current import is skipped
and another message is sent to the kernel to resolve the next import.