### PR TITLE
Fix bugs due to pyflyby cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Support to run `tidy-imports` on a notebook.
 
 - **Breaking**: Ported to JupyterLab 4.x
 
+## [4.3.2](https://github.com/deshaw/jupyterlab-pyflyby/compare/v4.3.1...v4.3.2) (UNRELEASED)
+
+### Fixed
+
+- Fixed a bug where multiple clicks of the TidyImportsButton caused the notebook to be modified in unexpected ways. Some of these were -
+  - Outputs of cells being mismatched when reconstructing the notebook.
+  - Addition of random cells above and below the pyflyby tagged cell.
+  - Mutliple clicks of the TidyImportButton would keep adding extra lines in the pyflyby cell.
+
 ## [4.3.1](https://github.com/deshaw/jupyterlab-pyflyby/compare/v4.3.0...v4.3.1) (2023-08-10)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Support to run `tidy-imports` on a notebook.
 - Fixed a bug where multiple clicks of the TidyImportsButton caused the notebook to be modified in unexpected ways. Some of these were -
   - Outputs of cells being mismatched when reconstructing the notebook.
   - Addition of random cells above and below the pyflyby tagged cell.
-  - Mutliple clicks of the TidyImportButton would keep adding extra lines in the pyflyby cell.
+  - Mutliple clicks of the TidyImportsButton would keep adding extra lines in the pyflyby cell.
 
 ## [4.3.1](https://github.com/deshaw/jupyterlab-pyflyby/compare/v4.3.0...v4.3.1) (2023-08-10)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deshaw/jupyterlab-pyflyby",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "A labextension to integrate pyflyby with notebooks",
   "keywords": [
     "jupyter",

--- a/src/cellUtils.ts
+++ b/src/cellUtils.ts
@@ -1,7 +1,7 @@
 import { toArray } from '@lumino/algorithm';
 import { MultilineString } from '@jupyterlab/nbformat';
 import { ICellModel } from '@jupyterlab/cells';
-import { PYFLYBY_END_MSG } from './constants';
+import { PYFLYBY_END_MSG, PYFLYBY_START_MSG } from './constants';
 
 // FIXME: There's got to be a better Typescript solution
 // for distinguishing between members of a union type at runtime.
@@ -118,4 +118,34 @@ export const findLinePos = (cell: ICellModel): number => {
   // Cell contains only comments or magics, so return -1.
   // These imports will be moved to next cell
   return -1;
+};
+
+/**
+ * Find the line number which contains the PYFLYBY_END_MSG.
+ * Returns -1 if the PYFLYBY_END_MSG doesn't exist.
+ *
+ * @param cell - a cell model
+ */
+export const extractCodeFromPyflybyCell = (cell: ICellModel): string => {
+  const lines: string[] = normalizeMultilineString(cell.toJSON().source);
+
+  let stIdx = -1,
+    enIdx = -1;
+  for (let i = 0; i < lines.length; ++i) {
+    if (lines[i] === PYFLYBY_START_MSG.trim()) {
+      stIdx = i;
+    }
+    if (lines[i] === PYFLYBY_END_MSG.trim()) {
+      enIdx = i;
+    }
+  }
+
+  // we splice it twice to remove the pyflyby messages
+  const imports: string = lines
+    .splice(stIdx, enIdx - stIdx + 1)
+    .splice(stIdx + 1, enIdx - stIdx - 1)
+    .join();
+  const remainingCode: string = lines.join('');
+  console.log(imports, remainingCode);
+  return remainingCode;
 };

--- a/src/cellUtils.ts
+++ b/src/cellUtils.ts
@@ -121,8 +121,7 @@ export const findLinePos = (cell: ICellModel): number => {
 };
 
 /**
- * Find the line number which contains the PYFLYBY_END_MSG.
- * Returns -1 if the PYFLYBY_END_MSG doesn't exist.
+ * This code extracts non-imports lines from the pyflyby cell.
  *
  * @param cell - a cell model
  */

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -307,7 +307,6 @@ class PyflyByWidget extends Widget {
   }
 
   restoreNotebookAfterTidyImports(cellArray: any, imports: any): void {
-    const { cellIndex } = this._findAndSetImportCoordinates();
     const cells = this._context.model.cells;
     for (let i = 0; i < cellArray.length; ++i) {
       const cell = cells.get(i);
@@ -315,20 +314,19 @@ class PyflyByWidget extends Widget {
       cell.value.insert(0, cellArray[i].text.trim());
     }
     const joined_imports = imports.join('\n').trim();
-    if (cells.get(0).value.text.length === 0) {
-      cells.get(0).value.insert(0, joined_imports);
-    } else {
-      const cell = this._context.model.contentFactory.createCodeCell({
-        cell: {
-          source: joined_imports,
-          cell_type: 'code',
-          metadata: {
-            trusted: true
-          }
-        }
-      });
-      cells.insert(cellIndex, cell);
-    }
+    const { cellIndex } = this._findAndSetImportCoordinates();
+    cells
+      .get(cellIndex)
+      .value.remove(0, cells.get(cellIndex).value.text.length);
+
+    // `joined_imports` contains all the imports in the notebook so it is safe
+    // to wrap it under PYFLYBY comments and insert into the pyflyby cell directly
+    cells
+      .get(cellIndex)
+      .value.insert(
+        0,
+        `${PYFLYBY_START_MSG}${joined_imports}\n${PYFLYBY_END_MSG}`
+      );
   }
 
   _fastStringHash(str: string) {


### PR DESCRIPTION
This fixes a bug where multiple clicks of the `TidyImportButton` would modify the notebook in unexpected ways. Some of these were - 
1. Outputs of cells being mismatched when reconstructing the notebook.
2. Addition of random cells above and below the pyflyby tagged cell.
3. Mutliple clicks of the TidyImportButton would keep adding extra lines in the pyflyby cell.