### PR TITLE
Fix tidy-imports running on incorrect tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [5.1.3](https://github.com/deshaw/jupyterlab-pyflyby/compare/v5.1.2...v5.1.3) (UNRELEASED)
+
+### Fixed
+
+- Tidy-imports running on incorrect tabs
+
 ## [5.1.2](https://github.com/deshaw/jupyterlab-pyflyby/compare/v5.1.1...v5.1.2) (2024-02-28)
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deshaw/jupyterlab-pyflyby",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "A labextension to integrate pyflyby with notebooks",
   "keywords": [
     "jupyter",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "stylelint-config-recommended": "^8.0.0",
     "stylelint-config-standard": "^26.0.0",
     "stylelint-prettier": "^2.0.0",
-    "typescript": "~5.0.2",
+    "typescript": "^5.0.2",
     "yjs": "^13.5.40"
   },
   "jupyterlab": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -552,7 +552,10 @@ class PyflyByWidget extends Widget {
 
 // Namespace for tracking PyflyByWidget instances
 namespace Private {
-  const widgetMap = new WeakMap<DocumentRegistry.IContext<INotebookModel>, PyflyByWidget>();
+  const widgetMap = new WeakMap<
+    DocumentRegistry.IContext<INotebookModel>,
+    PyflyByWidget
+  >();
 
   export function registerPyflyByWidget(
     context: DocumentRegistry.IContext<INotebookModel>,
@@ -696,7 +699,7 @@ const extension: JupyterFrontEndPlugin<void> = {
   id: '@deshaw/jupyterlab-pyflyby:plugin',
   autoStart: true,
   requires: [ISettingRegistry, INotebookTracker, ICommandPalette],
-  activate: async function(
+  activate: async function (
     app: JupyterFrontEnd,
     registry: ISettingRegistry,
     tracker: INotebookTracker,
@@ -710,7 +713,9 @@ const extension: JupyterFrontEndPlugin<void> = {
       execute: () => {
         // Get the current notebook
         const current = tracker.currentWidget;
-        if (!current) return;
+        if (!current) {
+          return;
+        }
 
         // Get the PyflyByWidget for this notebook
         const widget = Private.findPyflyByWidget(current.context);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -67,7 +67,7 @@ const log = debug('PYFLYBY:');
 // Define a signal that will be used to communicate between widget extensions
 const pyflybySignal = new Signal<
   any,
-  { context: DocumentRegistry.IContext<INotebookModel>, action: string }
+  { context: DocumentRegistry.IContext<INotebookModel>; action: string }
 >({});
 
 class CommLock {
@@ -193,7 +193,10 @@ class PyflyByWidget extends Widget {
     pyflybySignal.connect(this._handleSignal, this);
   }
 
-  private _handleSignal(_sender: any, args: { context: DocumentRegistry.IContext<INotebookModel>, action: string }) {
+  private _handleSignal(
+    _sender: any,
+    args: { context: DocumentRegistry.IContext<INotebookModel>; action: string }
+  ) {
     if (args.context === this._context && args.action === 'tidyImports') {
       this.sendTidyImportRequest();
     }
@@ -653,7 +656,8 @@ const installationBody = (
 );
 
 class TidyImportButtonExtension
-  implements DocumentRegistry.IWidgetExtension<NotebookPanel, INotebookModel> {
+  implements DocumentRegistry.IWidgetExtension<NotebookPanel, INotebookModel>
+{
   createNew(
     widget: NotebookPanel,
     context: DocumentRegistry.IContext<INotebookModel>
@@ -689,7 +693,7 @@ const extension: JupyterFrontEndPlugin<void> = {
   id: '@deshaw/jupyterlab-pyflyby:plugin',
   autoStart: true,
   requires: [ISettingRegistry, INotebookTracker, ICommandPalette],
-  activate: async function(
+  activate: async function (
     app: JupyterFrontEnd,
     registry: ISettingRegistry,
     tracker: INotebookTracker,
@@ -703,7 +707,9 @@ const extension: JupyterFrontEndPlugin<void> = {
       execute: () => {
         // Get the current notebook
         const current = tracker.currentWidget;
-        if (!current) return;
+        if (!current) {
+          return;
+        }
 
         // Emit a signal for the current notebook context
         pyflybySignal.emit({

--- a/yarn.lock
+++ b/yarn.lock
@@ -343,7 +343,7 @@ __metadata:
     stylelint-config-recommended: ^8.0.0
     stylelint-config-standard: ^26.0.0
     stylelint-prettier: ^2.0.0
-    typescript: ~5.0.2
+    typescript: ^5.0.2
     yjs: ^13.5.40
   peerDependencies:
     react: ~17.0.1
@@ -5775,23 +5775,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.0.2":
-  version: 5.0.4
-  resolution: "typescript@npm:5.0.4"
+"typescript@npm:^5.0.2":
+  version: 5.8.3
+  resolution: "typescript@npm:5.8.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 82b94da3f4604a8946da585f7d6c3025fff8410779e5bde2855ab130d05e4fd08938b9e593b6ebed165bda6ad9292b230984f10952cf82f0a0ca07bbeaa08172
+  checksum: cb1d081c889a288b962d3c8ae18d337ad6ee88a8e81ae0103fa1fecbe923737f3ba1dbdb3e6d8b776c72bc73bfa6d8d850c0306eed1a51377d2fccdfd75d92c4
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@~5.0.2#~builtin<compat/typescript>":
-  version: 5.0.4
-  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=85af82"
+"typescript@patch:typescript@^5.0.2#~builtin<compat/typescript>":
+  version: 5.8.3
+  resolution: "typescript@patch:typescript@npm%3A5.8.3#~builtin<compat/typescript>::version=5.8.3&hash=85af82"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: bb309d320c59a26565fb3793dba550576ab861018ff3fd1b7fccabbe46ae4a35546bc45f342c0a0b6f265c801ccdf64ffd68f548f117ceb7f0eac4b805cd52a9
+  checksum: 1b503525a88ff0ff5952e95870971c4fb2118c17364d60302c21935dedcd6c37e6a0a692f350892bafcef6f4a16d09073fe461158547978d2f16fbe4cb18581c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
TidyImports was picking up the incorrect context. The context used to be auto updated when notebook change but that doesn't happen anymore. So each notebook has an separate instance of the tidy-imports button now and this fixes the issue. 